### PR TITLE
Make event endpoint configurable, bump to 3.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 0.3.1
+
+### Enhancements
+
+* Event tracking endpoint is now configurable via `:event_endpoint`, allowing it to be changed for testing purposes.
+
+### Fixes
+
+* `ActiveCampaign.Tracking.Event.track/3` response json is now decoded.
+
 ## 0.3.0
 
 ### Enhancements

--- a/lib/active_campaign/config.ex
+++ b/lib/active_campaign/config.ex
@@ -4,37 +4,27 @@ defmodule ActiveCampaign.Config do
   """
 
   @api_version_path "/api/3/"
+  @event_endpoint "https://trackcmp.net/event"
 
-  def api_key do
-    Application.get_env(
-      :active_campaign,
-      :api_key
-    )
-  end
+  def api_key, do: get_env(:api_key)
 
   def api_url do
-    :active_campaign
-    |> Application.get_env(:api_url)
+    :api_url
+    |> get_env()
     |> URI.merge(@api_version_path)
   end
 
-  def event_key do
-    Application.get_env(:active_campaign, :event_key)
-  end
+  def event_key, do: get_env(:event_key)
 
-  def actid do
-    Application.get_env(:active_campaign, :actid)
-  end
+  def actid, do: get_env(:actid)
 
-  def json_library do
-    Application.get_env(:active_campaign, :json_library, Jason)
-  end
+  def json_library, do: get_env(:json_library, Jason)
 
-  def http_library do
-    Application.get_env(:active_campaign, :http_library, HTTPoison)
-  end
+  def http_library, do: get_env(:http_library, HTTPoison)
 
-  def http_options do
-    Application.get_env(:active_campaign, :http_options, [])
-  end
+  def http_options, do: get_env(:http_options, [])
+
+  def event_endpoint, do: get_env(:event_endpoint, @event_endpoint)
+
+  defp get_env(name, default \\ nil), do: Application.get_env(:active_campaign, name, default)
 end

--- a/lib/active_campaign/http.ex
+++ b/lib/active_campaign/http.ex
@@ -53,10 +53,11 @@ defmodule ActiveCampaign.Http do
   end
 
   def parse_response({:ok, %{body: body, headers: headers}}) do
-    if {"Content-Type", "application/json"} in headers do
-      Config.json_library().decode(body)
-    else
-      {:ok, body}
+    headers
+    |> Enum.find_value(fn {h, v} -> String.downcase(h) == "content-type" && String.downcase(v) end)
+    |> case do
+      "application/json" <> _ -> Config.json_library().decode(body)
+      _ -> {:ok, body}
     end
   end
 

--- a/lib/active_campaign/tracking/event.ex
+++ b/lib/active_campaign/tracking/event.ex
@@ -2,28 +2,32 @@ defmodule ActiveCampaign.Tracking.Event do
   @moduledoc """
   Documentation for `ActiveCampaign.Tracking.Event`.
   """
-  @event_url "https://trackcmp.net/event"
 
   alias ActiveCampaign.Http
   alias ActiveCampaign.Config
 
   @doc """
-  Track event
+  Track an event
+
+  ## Example
+
+    iex> ActiveCampaign.Tracking.Event.track("login", "sso", %{email: "jane.d@email.com"})
+    {:ok, %{"message" => "Event spawned", "success" => 1}}
   """
   @spec track(String.t(), String.t(), map()) :: {:ok, map()} | {:error, any()}
-  def track(event, eventdata, visit) do
+  def track(event, event_data, visit) do
     visit_json = Config.json_library().encode!(visit)
 
     payload = %{
       "actid" => Config.actid(),
       "key" => Config.event_key(),
       "event" => event,
-      "eventdata" => eventdata,
+      "eventdata" => event_data,
       "visit" => visit_json
     }
 
-    header = ["Content-Type": "application/x-www-form-urlencoded"]
-    response = Config.http_library().request(:post, @event_url, URI.encode_query(payload), header, Config.http_options())
+    headers = ["Content-Type": "application/x-www-form-urlencoded"]
+    response = Config.http_library().request(:post, Config.event_endpoint(), URI.encode_query(payload), headers, Config.http_options())
     Http.parse_response(response)
   end
 

--- a/lib/active_campaign/tracking/event.ex
+++ b/lib/active_campaign/tracking/event.ex
@@ -11,8 +11,8 @@ defmodule ActiveCampaign.Tracking.Event do
 
   ## Example
 
-    iex> ActiveCampaign.Tracking.Event.track("login", "sso", %{email: "jane.d@email.com"})
-    {:ok, %{"message" => "Event spawned", "success" => 1}}
+      iex> ActiveCampaign.Tracking.Event.track("login", "sso", %{email: "jane.d@email.com"})
+      {:ok, %{"message" => "Event spawned", "success" => 1}}
   """
   @spec track(String.t(), String.t(), map()) :: {:ok, map()} | {:error, any()}
   def track(event, event_data, visit) do

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule ActiveCampaign.MixProject do
   use Mix.Project
 
   @source_url "https://github.com/Health-Union/active_campaign"
-  @version "0.3.0"
+  @version "0.3.1"
 
   def project do
     [


### PR DESCRIPTION
It's more difficult to write unit tests around event tracking when we can't override the endpoint.

This PR adds the ability to configure the event endpoint.